### PR TITLE
fix(core): handle external routed self payments bundle

### DIFF
--- a/core/api/test/unit/ledger/ln-payment-state.spec.ts
+++ b/core/api/test/unit/ledger/ln-payment-state.spec.ts
@@ -9,412 +9,414 @@ const now = new Date(Date.now())
 const prev = new Date(now.getTime() - 1000)
 
 describe("LnPaymentState", () => {
-  describe("Pending", () => {
-    it("return Pending", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: true,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.Pending)
+  describe("Payment-only transactions", () => {
+    describe("Pending", () => {
+      it("return Pending", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: true,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.Pending)
+      })
+
+      it("return PendingAfterRetry", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: true,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.PendingAfterRetry)
+      })
     })
 
-    it("return PendingAfterRetry", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: true,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.PendingAfterRetry)
-    })
-  })
+    describe("Success", () => {
+      it("return Success", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.Success)
+      })
 
-  describe("Success", () => {
-    it("return Success", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.Success)
-    })
+      it("return SuccessWithReimbursement", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.LnFeeReimbursement,
+            pendingConfirmation: false,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.SuccessWithReimbursement)
+      })
 
-    it("return SuccessWithReimbursement", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.LnFeeReimbursement,
-          pendingConfirmation: false,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.SuccessWithReimbursement)
-    })
+      it("return SuccessAfterRetry", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.SuccessAfterRetry)
+      })
 
-    it("return SuccessAfterRetry", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.SuccessAfterRetry)
-    })
-
-    it("return SuccessWithReimbursementAfterRetry", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-          credit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.LnFeeReimbursement,
-          pendingConfirmation: false,
-          debit: 0,
-          credit: 2,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-          credit: 0,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.SuccessWithReimbursementAfterRetry)
-    })
-  })
-
-  describe("Failed", () => {
-    it("return Failed", () => {
-      const txnsBtc = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-          credit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txBtcState = LnPaymentStateDeterminator(txnsBtc).determine()
-      expect(txBtcState).toEqual(LnPaymentState.Failed)
-
-      const txnsUsd = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 5,
-          credit: 0,
-        } as LedgerTransaction<"USD">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-          lnMemo: FAILED_USD_MEMO,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txUsdState = LnPaymentStateDeterminator(txnsUsd).determine()
-      expect(txUsdState).toEqual(LnPaymentState.Failed)
+      it("return SuccessWithReimbursementAfterRetry", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+            credit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.LnFeeReimbursement,
+            pendingConfirmation: false,
+            debit: 0,
+            credit: 2,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+            credit: 0,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.SuccessWithReimbursementAfterRetry)
+      })
     })
 
-    it("return Failed with USD", () => {
-      const txnsBtc = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 2,
-          credit: 0,
-        } as LedgerTransaction<"USD">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-          lnMemo: FAILED_USD_MEMO,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txBtcState = LnPaymentStateDeterminator(txnsBtc).determine()
-      expect(txBtcState).toEqual(LnPaymentState.Failed)
+    describe("Failed", () => {
+      it("return Failed", () => {
+        const txnsBtc = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+            credit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txBtcState = LnPaymentStateDeterminator(txnsBtc).determine()
+        expect(txBtcState).toEqual(LnPaymentState.Failed)
 
-      const txnsUsd = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 5,
-          credit: 0,
-        } as LedgerTransaction<"USD">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-          lnMemo: FAILED_USD_MEMO,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txUsdState = LnPaymentStateDeterminator(txnsUsd).determine()
-      expect(txUsdState).toEqual(LnPaymentState.Failed)
-    })
+        const txnsUsd = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 5,
+            credit: 0,
+          } as LedgerTransaction<"USD">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+            lnMemo: FAILED_USD_MEMO,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txUsdState = LnPaymentStateDeterminator(txnsUsd).determine()
+        expect(txUsdState).toEqual(LnPaymentState.Failed)
+      })
 
-    it("return FailedAfterRetry", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-          credit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-          credit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.FailedAfterRetry)
-    })
+      it("return Failed with USD", () => {
+        const txnsBtc = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 2,
+            credit: 0,
+          } as LedgerTransaction<"USD">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+            lnMemo: FAILED_USD_MEMO,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txBtcState = LnPaymentStateDeterminator(txnsBtc).determine()
+        expect(txBtcState).toEqual(LnPaymentState.Failed)
 
-    it("return FailedAfterRetry with USD", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-          credit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 2,
-          credit: 0,
-        } as LedgerTransaction<"USD">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-          lnMemo: FAILED_USD_MEMO,
-        } as LedgerTransaction<"BTC">,
-      ]
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.FailedAfterRetry)
-    })
+        const txnsUsd = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 5,
+            credit: 0,
+          } as LedgerTransaction<"USD">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+            lnMemo: FAILED_USD_MEMO,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txUsdState = LnPaymentStateDeterminator(txnsUsd).determine()
+        expect(txUsdState).toEqual(LnPaymentState.Failed)
+      })
 
-    it("return FailedAfterSuccess", () => {
-      const now = new Date(Date.now())
-      const prev = new Date(now.getTime() - 1000)
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-      ]
+      it("return FailedAfterRetry", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+            credit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+            credit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.FailedAfterRetry)
+      })
 
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.FailedAfterSuccess)
-    })
+      it("return FailedAfterRetry with USD", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+            credit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 2,
+            credit: 0,
+          } as LedgerTransaction<"USD">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+            lnMemo: FAILED_USD_MEMO,
+          } as LedgerTransaction<"BTC">,
+        ]
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.FailedAfterRetry)
+      })
 
-    it("return FailedAfterSuccess with USD", () => {
-      const now = new Date(Date.now())
-      const prev = new Date(now.getTime() - 1000)
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-          lnMemo: FAILED_USD_MEMO,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 2,
-          credit: 0,
-        } as LedgerTransaction<"USD">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-      ]
+      it("return FailedAfterSuccess", () => {
+        const now = new Date(Date.now())
+        const prev = new Date(now.getTime() - 1000)
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+        ]
 
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.FailedAfterSuccess)
-    })
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.FailedAfterSuccess)
+      })
 
-    it("return FailedAfterSuccessWithReimbursement", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.LnFeeReimbursement,
-          pendingConfirmation: false,
-          credit: 1,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-      ]
+      it("return FailedAfterSuccess with USD", () => {
+        const now = new Date(Date.now())
+        const prev = new Date(now.getTime() - 1000)
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+            lnMemo: FAILED_USD_MEMO,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 2,
+            credit: 0,
+          } as LedgerTransaction<"USD">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+        ]
 
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.FailedAfterSuccessWithReimbursement)
-    })
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.FailedAfterSuccess)
+      })
 
-    it("return FailedAfterSuccessWithReimbursement with USD", () => {
-      const txns = [
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          credit: 100,
-          debit: 0,
-          lnMemo: FAILED_USD_MEMO,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: now,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 2,
-          credit: 0,
-        } as LedgerTransaction<"USD">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.LnFeeReimbursement,
-          pendingConfirmation: false,
-          credit: 1,
-        } as LedgerTransaction<"BTC">,
-        {
-          timestamp: prev,
-          type: LedgerTransactionType.Payment,
-          pendingConfirmation: false,
-          debit: 100,
-        } as LedgerTransaction<"BTC">,
-      ]
+      it("return FailedAfterSuccessWithReimbursement", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.LnFeeReimbursement,
+            pendingConfirmation: false,
+            credit: 1,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+        ]
 
-      const txState = LnPaymentStateDeterminator(txns).determine()
-      expect(txState).toEqual(LnPaymentState.FailedAfterSuccessWithReimbursement)
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.FailedAfterSuccessWithReimbursement)
+      })
+
+      it("return FailedAfterSuccessWithReimbursement with USD", () => {
+        const txns = [
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            credit: 100,
+            debit: 0,
+            lnMemo: FAILED_USD_MEMO,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: now,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 2,
+            credit: 0,
+          } as LedgerTransaction<"USD">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.LnFeeReimbursement,
+            pendingConfirmation: false,
+            credit: 1,
+          } as LedgerTransaction<"BTC">,
+          {
+            timestamp: prev,
+            type: LedgerTransactionType.Payment,
+            pendingConfirmation: false,
+            debit: 100,
+          } as LedgerTransaction<"BTC">,
+        ]
+
+        const txState = LnPaymentStateDeterminator(txns).determine()
+        expect(txState).toEqual(LnPaymentState.FailedAfterSuccessWithReimbursement)
+      })
     })
   })
 


### PR DESCRIPTION
## Description

This can happen for example when geyser creates an invoice in our system and forwards to it via their own node when their lightning address is paid.