### PR TITLE
chore(notifications): do not persist txn notification to history

### DIFF
--- a/core/notifications/notifications.yml
+++ b/core/notifications/notifications.yml
@@ -7,7 +7,10 @@
 #   port: 6685
 app:
   # jobs:
-  #   kickoff_link_email_reminder_delay: 5
+  #   enabled: false
+  #   max_concurrent_jobs: 24
+  #   min_concurrent_jobs: 12
+  #   kickoff_link_email_reminder_delay: 21600
   # link_email_reminder:
   #   account_liveness_threshold_minutes: 30240
   #   account_aged_threshold_minutes: 30240

--- a/core/notifications/src/notification_event/transaction_occurred.rs
+++ b/core/notifications/src/notification_event/transaction_occurred.rs
@@ -85,16 +85,6 @@ impl NotificationEvent for TransactionOccurred {
 
         LocalizedPushMessage { title, body }
     }
-
-    fn to_localized_persistent_message(&self, locale: GaloyLocale) -> LocalizedStatefulMessage {
-        let push_msg = self.to_localized_push_msg(&locale);
-
-        LocalizedStatefulMessage {
-            locale,
-            title: push_msg.title,
-            body: push_msg.body,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/core/notifications/src/notification_event/transaction_occurred.rs
+++ b/core/notifications/src/notification_event/transaction_occurred.rs
@@ -86,10 +86,6 @@ impl NotificationEvent for TransactionOccurred {
         LocalizedPushMessage { title, body }
     }
 
-    fn should_be_added_to_history(&self) -> bool {
-        true
-    }
-
     fn to_localized_persistent_message(&self, locale: GaloyLocale) -> LocalizedStatefulMessage {
         let push_msg = self.to_localized_push_msg(&locale);
 

--- a/dev/config/notifications/notifications.yml
+++ b/dev/config/notifications/notifications.yml
@@ -2,3 +2,5 @@ app:
   push_executor:
     fcm:
       google_application_credentials_path: "./config/notifications/fake_service_account.json"
+  jobs:
+    enabled: true


### PR DESCRIPTION
This PR disables transaction_occurred to be added to notification history. It also refactors notifications e2e test to use marketing notification to send notifications to users.