### PR TITLE
refactor(dashboard): moving token to apollo client

### DIFF
--- a/apps/dashboard/app/api-keys/page.tsx
+++ b/apps/dashboard/app/api-keys/page.tsx
@@ -23,9 +23,7 @@ export default async function Home() {
     redirect("/")
   }
 
-  const keys = await apiKeys({
-    token,
-  })
+  const keys = await apiKeys()
 
   const activeKeys = keys.filter(({ expired, revoked }) => !expired && !revoked)
   const expiredKeys = keys.filter(({ expired }) => expired)

--- a/apps/dashboard/app/api-keys/server-actions.ts
+++ b/apps/dashboard/app/api-keys/server-actions.ts
@@ -29,7 +29,6 @@ export const revokeApiKeyServerAction = async (id: string) => {
 
   try {
     await revokeApiKey({
-      token,
       id,
     })
   } catch (err) {
@@ -101,7 +100,6 @@ export const createApiKeyServerAction = async (
   let data
   try {
     data = await createApiKey({
-      token,
       name: apiKeyName,
       expireInDays: apiKeyExpiresInDays,
       scopes,

--- a/apps/dashboard/app/api/auth/[...nextauth]/route.ts
+++ b/apps/dashboard/app/api/auth/[...nextauth]/route.ts
@@ -2,7 +2,7 @@ import NextAuth, { AuthOptions } from "next-auth"
 
 import { ApolloQueryResult } from "@apollo/client"
 
-import { fetchUserData } from "@/services/graphql/queries/me-data"
+import { fetchUserDataForSession } from "@/services/graphql/queries/me-data"
 import { env } from "@/env"
 import { MeQuery } from "@/services/graphql/generated"
 
@@ -61,7 +61,9 @@ export const authOptions: AuthOptions = {
         throw new Error("Invalid token")
       }
 
-      const userData = await fetchUserData({ token: token.accessToken })
+      // This is different from other core API functions as using ApolloClient directly will cause a recursive loop.
+      // Therefore, we are passing the token.
+      const userData = await fetchUserDataForSession({ token: token.accessToken })
       session.sub = token.sub
       session.accessToken = token.accessToken
       session.userData = userData

--- a/apps/dashboard/app/batch-payments/get-user-details-action.ts
+++ b/apps/dashboard/app/batch-payments/get-user-details-action.ts
@@ -17,7 +17,6 @@ export const getUserDetailsAction = async ({ username }: { username: string }) =
   }
 
   const response = await getWalletDetailsByUsername({
-    token,
     username,
   })
   if (response instanceof Error) {

--- a/apps/dashboard/app/batch-payments/server-actions.ts
+++ b/apps/dashboard/app/batch-payments/server-actions.ts
@@ -31,9 +31,7 @@ export const processPaymentsServerAction = async (records: ProcessedRecords[]) =
 
   const btcWallet = getBTCWallet(session.userData.data)
   const usdWallet = getUSDWallet(session.userData.data)
-  const realtimePrice = await getRealtimePriceQuery({
-    token,
-  })
+  const realtimePrice = await getRealtimePriceQuery()
   if (realtimePrice instanceof Error) {
     return {
       error: true,
@@ -53,7 +51,6 @@ export const processPaymentsServerAction = async (records: ProcessedRecords[]) =
     let response
     if (record.sendingWallet === WalletCurrency.Usd) {
       response = await intraLedgerUsdPaymentSend({
-        token,
         amount: dollarsToCents(record.amount),
         memo: record.memo,
         recipientWalletId: record.recipientWalletId,
@@ -82,7 +79,6 @@ export const processPaymentsServerAction = async (records: ProcessedRecords[]) =
         amount = convertUsdToBtcSats(record.amount, realtimePrice.data)
       }
       response = await intraLedgerBtcPaymentSend({
-        token,
         amount,
         memo: record.memo,
         recipientWalletId: record.recipientWalletId,
@@ -150,7 +146,6 @@ export const validatePaymentDetail = async (
     }
   }
 
-  const token = session.accessToken
   const btcWallet = getBTCWallet(session.userData.data)
   const usdWallet = getUSDWallet(session.userData.data)
 
@@ -162,7 +157,7 @@ export const validatePaymentDetail = async (
     }
   }
 
-  const realtimePrice = await getRealtimePriceQuery({ token })
+  const realtimePrice = await getRealtimePriceQuery()
   if (realtimePrice instanceof Error) {
     return {
       error: true,

--- a/apps/dashboard/app/callback/page.tsx
+++ b/apps/dashboard/app/callback/page.tsx
@@ -20,7 +20,7 @@ export default async function page() {
   }
   let response
   try {
-    response = await fetchCallbackData({ token })
+    response = await fetchCallbackData()
   } catch (err) {
     return null
   }

--- a/apps/dashboard/app/callback/server-actions.ts
+++ b/apps/dashboard/app/callback/server-actions.ts
@@ -34,7 +34,7 @@ export const createCallbackAction = async (
 
   let response
   try {
-    response = await callbackEndpointAdd({ url: callBackUrl, token })
+    response = await callbackEndpointAdd({ url: callBackUrl })
   } catch (err) {
     return {
       error: true,
@@ -79,7 +79,6 @@ export const deleteCallbackAction = async (
   try {
     response = await callbackEndpointDelete({
       id: callBackId,
-      token,
     })
   } catch (err) {
     return {

--- a/apps/dashboard/app/security/2fa/server-actions.ts
+++ b/apps/dashboard/app/security/2fa/server-actions.ts
@@ -32,7 +32,7 @@ export const totpRegisterInitiateServerAction =
 
     let data: UserTotpRegistrationInitiateMutation | null | undefined
     try {
-      data = await userTotpRegistrationInitiate({ token })
+      data = await userTotpRegistrationInitiate()
     } catch (err) {
       console.log("error in userTotpRegistrationInitiate ", err)
       return {
@@ -98,7 +98,6 @@ export const totpRegisterValidateServerAction = async (
     totpValidationResponse = await userTotpRegistrationValidate({
       totpCode,
       totpRegistrationId,
-      token,
     })
   } catch (err) {
     console.log("error in userTotpRegistrationValidate ", err)
@@ -127,6 +126,6 @@ export const deleteTotpServerAction = async () => {
   if (!token && typeof token !== "string") {
     return
   }
-  await userTotpDelete({ token })
+  await userTotpDelete()
   revalidatePath("/security")
 }

--- a/apps/dashboard/app/security/email/server-actions.ts
+++ b/apps/dashboard/app/security/email/server-actions.ts
@@ -43,7 +43,7 @@ export const emailRegisterInitiateServerAction = async (
 
   let data: UserEmailRegistrationInitiateMutation | null | undefined
   try {
-    data = await emailRegistrationInitiate({ email, token })
+    data = await emailRegistrationInitiate({ email })
   } catch (err) {
     console.log("error in emailRegistrationInitiate ", err)
     return {
@@ -102,7 +102,6 @@ export const emailRegisterValidateServerAction = async (
     codeVerificationResponse = await emailRegistrationValidate({
       code,
       emailRegistrationId,
-      token,
     })
   } catch (err) {
     console.log("error in emailRegistrationValidate ", err)
@@ -131,6 +130,6 @@ export const deleteEmailServerAction = async () => {
   if (!token && typeof token !== "string") {
     return
   }
-  await deleteEmail({ token })
+  await deleteEmail()
   revalidatePath("/security")
 }

--- a/apps/dashboard/app/security/email/verify/page.tsx
+++ b/apps/dashboard/app/security/email/verify/page.tsx
@@ -34,10 +34,10 @@ export default async function VerifyEmail({
   }
 
   if (!emailRegistrationId || typeof emailRegistrationId !== "string") {
-    await deleteEmail({ token })
+    await deleteEmail()
     let data: UserEmailRegistrationInitiateMutation | null | undefined
     try {
-      data = await emailRegistrationInitiate({ email, token })
+      data = await emailRegistrationInitiate({ email })
     } catch (err) {
       console.log("error in emailRegistrationInitiate ", err)
       redirect("/security")

--- a/apps/dashboard/app/transactions/page.tsx
+++ b/apps/dashboard/app/transactions/page.tsx
@@ -34,13 +34,12 @@ export default async function page({
   let response
   if (cursor && direction) {
     response = await fetchPaginatedTransactions({
-      token,
       direction,
       cursor,
       first: numberOfTransactions,
     })
   } else {
-    response = await fetchFirstTransactions({ token, first: numberOfTransactions })
+    response = await fetchFirstTransactions({ first: numberOfTransactions })
   }
 
   const rows = response?.edges?.map((edge) => ({ node: edge.node })) ?? []

--- a/apps/dashboard/services/graphql/index.ts
+++ b/apps/dashboard/services/graphql/index.ts
@@ -1,29 +1,44 @@
 import { ApolloClient, HttpLink, InMemoryCache } from "@apollo/client"
-
 import { registerApolloClient } from "@apollo/experimental-nextjs-app-support/rsc"
-
 import { propagation, context } from "@opentelemetry/api"
 
-import { env } from "@/env"
+import { getServerSession } from "next-auth"
 
-export const apollo = (token: string) =>
-  registerApolloClient(() => {
-    return new ApolloClient({
-      cache: new InMemoryCache(),
-      link: new HttpLink({
-        headers: {
-          ["Oauth2-Token"]: token,
-        },
-        uri: env.CORE_URL,
-        fetchOptions: { cache: "no-store" },
-        fetch: (uri, options) => {
-          const headersWithTrace = options?.headers || {}
-          propagation.inject(context.active(), headersWithTrace)
-          return fetch(uri, {
-            ...options,
-            headers: headersWithTrace,
-          })
-        },
+import { redirect } from "next/navigation"
+
+import { env } from "@/env"
+import { authOptions } from "@/app/api/auth/[...nextauth]/route"
+
+export const apollo = (token: string) => {
+  return registerApolloClient(
+    () =>
+      new ApolloClient({
+        cache: new InMemoryCache(),
+        link: new HttpLink({
+          headers: {
+            ["Oauth2-Token"]: token,
+          },
+          uri: env.CORE_URL,
+          fetchOptions: { cache: "no-store" },
+          fetch: (uri, options) => {
+            const headersWithTrace = options?.headers || {}
+            propagation.inject(context.active(), headersWithTrace)
+            return fetch(uri, {
+              ...options,
+              headers: headersWithTrace,
+            })
+          },
+        }),
       }),
-    })
-  })
+  ).getClient()
+}
+
+export const apolloClient = {
+  authenticated: async (): Promise<ApolloClient<unknown>> => {
+    const session = await getServerSession(authOptions)
+    if (!session || !session?.accessToken) {
+      return redirect("/api/auth/signin")
+    }
+    return apollo(session.accessToken)
+  },
+}

--- a/apps/dashboard/services/graphql/mutations/api-keys.ts
+++ b/apps/dashboard/services/graphql/mutations/api-keys.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import {
   ApiKeyCreateDocument,
   ApiKeyCreateMutation,
@@ -43,17 +43,15 @@ gql`
 `
 
 export async function createApiKey({
-  token,
   name,
   expireInDays,
   scopes,
 }: {
-  token: string
   name: string
   expireInDays: number | null
   scopes: Scope[]
 }) {
-  const client = apollo(token).getClient()
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<ApiKeyCreateMutation>({
       mutation: ApiKeyCreateDocument,
@@ -66,8 +64,8 @@ export async function createApiKey({
   }
 }
 
-export async function revokeApiKey({ token, id }: { token: string; id: string }) {
-  const client = apollo(token).getClient()
+export async function revokeApiKey({ id }: { id: string }) {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<ApiKeyRevokeMutation>({
       mutation: ApiKeyRevokeDocument,

--- a/apps/dashboard/services/graphql/mutations/callback-mutation.ts
+++ b/apps/dashboard/services/graphql/mutations/callback-mutation.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import {
   CallbackEndpointAddMutation,
   CallbackEndpointAddDocument,
@@ -31,14 +31,8 @@ gql`
     }
   }
 `
-export async function callbackEndpointAdd({
-  url,
-  token,
-}: {
-  url: string
-  token: string
-}) {
-  const client = apollo(token).getClient()
+export async function callbackEndpointAdd({ url }: { url: string }) {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<CallbackEndpointAddMutation>({
       mutation: CallbackEndpointAddDocument,
@@ -51,14 +45,8 @@ export async function callbackEndpointAdd({
   }
 }
 
-export async function callbackEndpointDelete({
-  token,
-  id,
-}: {
-  token: string
-  id: string
-}) {
-  const client = apollo(token).getClient()
+export async function callbackEndpointDelete({ id }: { id: string }) {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<CallbackEndpointDeleteMutation>({
       mutation: CallbackEndpointDeleteDocument,

--- a/apps/dashboard/services/graphql/mutations/email.ts
+++ b/apps/dashboard/services/graphql/mutations/email.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import {
   UserEmailDeleteDocument,
   UserEmailDeleteMutation,
@@ -40,14 +40,8 @@ gql`
   }
 `
 
-export async function emailRegistrationInitiate({
-  email,
-  token,
-}: {
-  email: string
-  token: string
-}) {
-  const client = apollo(token).getClient()
+export async function emailRegistrationInitiate({ email }: { email: string }) {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<UserEmailRegistrationInitiateMutation>({
       mutation: UserEmailRegistrationInitiateDocument,
@@ -63,13 +57,11 @@ export async function emailRegistrationInitiate({
 export async function emailRegistrationValidate({
   emailRegistrationId,
   code,
-  token,
 }: {
   emailRegistrationId: string
   code: string
-  token: string
 }) {
-  const client = apollo(token).getClient()
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<UserEmailRegistrationValidateMutation>({
       mutation: UserEmailRegistrationValidateDocument,
@@ -87,8 +79,8 @@ export async function emailRegistrationValidate({
   }
 }
 
-export async function deleteEmail({ token }: { token: string }) {
-  const client = apollo(token).getClient()
+export async function deleteEmail() {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<UserEmailDeleteMutation>({
       mutation: UserEmailDeleteDocument,

--- a/apps/dashboard/services/graphql/mutations/intra-ledger-payment-send/btc.ts
+++ b/apps/dashboard/services/graphql/mutations/intra-ledger-payment-send/btc.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from "../.."
+import { apolloClient } from "../.."
 
 import {
   IntraLedgerBtcPaymentSendDocument,
@@ -20,19 +20,17 @@ gql`
 `
 
 export async function intraLedgerBtcPaymentSend({
-  token,
   amount,
   memo,
   recipientWalletId,
   walletId,
 }: {
-  token: string
   amount: number
   memo?: string
   recipientWalletId: string
   walletId: string
 }) {
-  const client = apollo(token).getClient()
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<IntraLedgerBtcPaymentSendMutation>({
       mutation: IntraLedgerBtcPaymentSendDocument,

--- a/apps/dashboard/services/graphql/mutations/intra-ledger-payment-send/usd.ts
+++ b/apps/dashboard/services/graphql/mutations/intra-ledger-payment-send/usd.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from "../.."
+import { apolloClient } from "../.."
 import {
   IntraLedgerUsdPaymentSendDocument,
   IntraLedgerUsdPaymentSendMutation,
@@ -19,19 +19,17 @@ gql`
 `
 
 export async function intraLedgerUsdPaymentSend({
-  token,
   amount,
   memo,
   recipientWalletId,
   walletId,
 }: {
-  token: string
   amount: number
   memo?: string
   recipientWalletId: string
   walletId: string
 }) {
-  const client = apollo(token).getClient()
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<IntraLedgerUsdPaymentSendMutation>({
       mutation: IntraLedgerUsdPaymentSendDocument,

--- a/apps/dashboard/services/graphql/mutations/totp.ts
+++ b/apps/dashboard/services/graphql/mutations/totp.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import {
   UserTotpDeleteDocument,
   UserTotpDeleteMutation,
@@ -47,8 +47,8 @@ gql`
   }
 `
 
-export async function userTotpRegistrationInitiate({ token }: { token: string }) {
-  const client = apollo(token).getClient()
+export async function userTotpRegistrationInitiate() {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<UserTotpRegistrationInitiateMutation>({
       mutation: UserTotpRegistrationInitiateDocument,
@@ -61,15 +61,13 @@ export async function userTotpRegistrationInitiate({ token }: { token: string })
 }
 
 export async function userTotpRegistrationValidate({
-  token,
   totpRegistrationId,
   totpCode,
 }: {
-  token: string
   totpRegistrationId: string
   totpCode: string
 }) {
-  const client = apollo(token).getClient()
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<UserTotpRegistrationValidateMutation>({
       mutation: UserTotpRegistrationValidateDocument,
@@ -87,8 +85,8 @@ export async function userTotpRegistrationValidate({
   }
 }
 
-export async function userTotpDelete({ token }: { token: string }) {
-  const client = apollo(token).getClient()
+export async function userTotpDelete() {
+  const client = await apolloClient.authenticated()
   try {
     const { data } = await client.mutate<UserTotpDeleteMutation>({
       mutation: UserTotpDeleteDocument,

--- a/apps/dashboard/services/graphql/queries/api-keys.ts
+++ b/apps/dashboard/services/graphql/queries/api-keys.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import { ApiKeysDocument, ApiKeysQuery } from "../generated"
 
 gql`
@@ -21,8 +21,8 @@ gql`
   }
 `
 
-export async function apiKeys({ token }: { token: string }) {
-  const client = apollo(token).getClient()
+export async function apiKeys() {
+  const client = await apolloClient.authenticated()
 
   try {
     const { data } = await client.query<ApiKeysQuery>({

--- a/apps/dashboard/services/graphql/queries/callback-query.ts
+++ b/apps/dashboard/services/graphql/queries/callback-query.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import { CallbackEndpointsDocument, CallbackEndpointsQuery } from "../generated"
 
 gql`
@@ -16,8 +16,8 @@ gql`
   }
 `
 
-export async function fetchCallbackData({ token }: { token: string }) {
-  const client = apollo(token).getClient()
+export async function fetchCallbackData() {
+  const client = await apolloClient.authenticated()
   try {
     const response = await client.query<CallbackEndpointsQuery>({
       query: CallbackEndpointsDocument,

--- a/apps/dashboard/services/graphql/queries/get-transactions.ts
+++ b/apps/dashboard/services/graphql/queries/get-transactions.ts
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client"
 
-import { apollo } from ".."
+import { apolloClient } from ".."
 import {
   GetFirstTransactionsDocument,
   GetFirstTransactionsQuery,
@@ -141,14 +141,8 @@ gql`
   }
 `
 
-export async function fetchFirstTransactions({
-  token,
-  first,
-}: {
-  token: string
-  first: number
-}) {
-  const client = apollo(token).getClient()
+export async function fetchFirstTransactions({ first }: { first: number }) {
+  const client = await apolloClient.authenticated()
 
   try {
     const data = await client.query<GetFirstTransactionsQuery>({
@@ -166,17 +160,15 @@ export async function fetchFirstTransactions({
 }
 
 export async function fetchPaginatedTransactions({
-  token,
   first,
   cursor,
   direction,
 }: {
-  token: string
   first: number
   cursor: string | null
   direction: "next" | "previous"
 }) {
-  const client = apollo(token).getClient()
+  const client = await apolloClient.authenticated()
 
   let variables: {
     first: number

--- a/apps/dashboard/services/graphql/queries/get-user-wallet-id.ts
+++ b/apps/dashboard/services/graphql/queries/get-user-wallet-id.ts
@@ -4,7 +4,7 @@ import {
   GetDefaultWalletByUsernameDocument,
   GetDefaultWalletByUsernameQuery,
 } from "../generated"
-import { apollo } from ".."
+import { apolloClient } from ".."
 
 gql`
   query GetDefaultWalletByUsername($username: Username!) {
@@ -14,14 +14,8 @@ gql`
     }
   }
 `
-export async function getWalletDetailsByUsername({
-  token,
-  username,
-}: {
-  token: string
-  username: string
-}) {
-  const client = apollo(token).getClient()
+export async function getWalletDetailsByUsername({ username }: { username: string }) {
+  const client = await apolloClient.authenticated()
 
   try {
     const data = await client.query<GetDefaultWalletByUsernameQuery>({

--- a/apps/dashboard/services/graphql/queries/me-data.ts
+++ b/apps/dashboard/services/graphql/queries/me-data.ts
@@ -34,9 +34,8 @@ gql`
   }
 `
 
-export async function fetchUserData({ token }: { token: string }) {
-  const client = apollo(token).getClient()
-
+export async function fetchUserDataForSession({ token }: { token: string }) {
+  const client = apollo(token)
   try {
     const data = await client.query<MeQuery>({
       query: MeDocument,

--- a/apps/dashboard/services/graphql/queries/realtime-price.ts
+++ b/apps/dashboard/services/graphql/queries/realtime-price.ts
@@ -1,7 +1,7 @@
 import { gql } from "@apollo/client"
 
 import { RealtimePriceDocument, RealtimePriceQuery } from "../generated"
-import { apollo } from ".."
+import { apolloClient } from ".."
 
 gql`
   query RealtimePrice($currency: DisplayCurrency) {
@@ -21,8 +21,8 @@ gql`
   }
 `
 
-export async function getRealtimePriceQuery({ token }: { token: string }) {
-  const client = apollo(token).getClient()
+export async function getRealtimePriceQuery() {
+  const client = await apolloClient.authenticated()
 
   try {
     const data = await client.query<RealtimePriceQuery>({


### PR DESCRIPTION
Before, we were passing the client from the core API (Blink API) function invocation to the Apollo client instance. Now, we are using `getServerSession` to directly get the token when calling the Apollo client instance.