### PR TITLE
revert: "ci: use kaniko builder"

### DIFF
--- a/ci/apps/app-template.lib.yml
+++ b/ci/apps/app-template.lib.yml
@@ -107,29 +107,24 @@ plan:
       run:
         path: pipeline-tasks/ci/apps/tasks/prepare-docker-build.sh
   - task: build
-    #@ def build_args(app):
-    #@ dockerfile_path = "repo/apps/" + app + "/Dockerfile"
-    #@ build_args_command = "$(awk -F= '{print \"--build-arg=\"$1\"=\"$2}' repo/.build-args)"
-    #@ kaniko_args="/kaniko/executor --context=repo --use-new-run --single-snapshot --cache=false --no-push --tar-path=image/image.tar --dockerfile=" + dockerfile_path + " " + build_args_command
-    #@ args = ["-exc"]
-    #@ args.append(kaniko_args)
-    #@ return args
-    #@ end
     attempts: 2
+    privileged: true
     config:
       platform: linux
       image_resource:
         type: registry-image
         source:
-          repository: gcr.io/kaniko-project/executor
-          tag: debug
+          repository: vito/oci-build-task
       inputs:
         - name: repo
       outputs:
         - name: image
+      params:
+        CONTEXT: repo
+        DOCKERFILE: #@ "repo/apps/" + app + "/Dockerfile"
+        BUILD_ARGS_FILE: repo/.build-args
       run:
-        path: /bin/sh
-        args: #@ build_args(app)
+        path: build
   - put: #@ edge_image_resource_name(app)
     params:
       image: image/image.tar

--- a/ci/core/template.lib.yml
+++ b/ci/core/template.lib.yml
@@ -205,29 +205,24 @@ plan:
       run:
         path: pipeline-tasks/ci/core/tasks/prepare-docker-build.sh
   - task: build
-    #@ def build_args(component):
-    #@ dockerfile_path = "repo/core/" + component + "/Dockerfile" + post_fix
-    #@ build_args_command = "$(awk -F= '{print \"--build-arg=\"$1\"=\"$2}' repo/.build-args)"
-    #@ kaniko_args="/kaniko/executor --context=repo --use-new-run --single-snapshot --cache=false --no-push --tar-path=image/image.tar --dockerfile=" + dockerfile_path + " " + build_args_command
-    #@ args = ["-exc"]
-    #@ args.append(kaniko_args)
-    #@ return args
-    #@ end
     attempts: 2
+    privileged: true
     config:
       platform: linux
       image_resource:
         type: registry-image
         source:
-          repository: gcr.io/kaniko-project/executor
-          tag: debug
+          repository: vito/oci-build-task
       inputs:
         - name: repo
       outputs:
         - name: image
+      params:
+        CONTEXT: repo
+        DOCKERFILE: #@ "repo/core/" + component + "/Dockerfile" + post_fix
+        BUILD_ARGS_FILE: repo/.build-args
       run:
-        path: /bin/sh
-        args: #@ build_args(component)
+        path: build
   - put: #@ edge_image_resource_name(component + post_fix)
     params:
       image: image/image.tar


### PR DESCRIPTION
Reverting back to the old builder while we figure out how to reduce kaniko build times.