### PR TITLE
feat(notifications): query and counts for non bulletins

### DIFF
--- a/bats/gql/list-stateful-notifications-without-bulletin-enabled.gql
+++ b/bats/gql/list-stateful-notifications-without-bulletin-enabled.gql
@@ -1,0 +1,19 @@
+query listStatefulNotificationsWithoutBulletinEnabled($first: Int = 2, $after: String = null) {
+  me {
+    id
+    statefulNotifications(first: $first, after: $after) {
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+      nodes {
+        id
+        body
+        title
+        deepLink
+        acknowledgedAt
+        createdAt
+      }
+    }
+  }
+}

--- a/core/notifications/.sqlx/query-226ebb1c711fd0af3205d22b7896dc95cb6efc3d5ca8d1ee070422977c3d5687.json
+++ b/core/notifications/.sqlx/query-226ebb1c711fd0af3205d22b7896dc95cb6efc3d5ca8d1ee070422977c3d5687.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT COUNT(*) AS \"count!\"\n            FROM stateful_notifications\n            WHERE galoy_user_id = $1 AND acknowledged = FALSE",
+  "query": "SELECT COUNT(*) AS \"count!\"\n            FROM stateful_notifications\n            WHERE galoy_user_id = $1 AND acknowledged = FALSE AND bulletin_enabled = FALSE",
   "describe": {
     "columns": [
       {
@@ -18,5 +18,5 @@
       null
     ]
   },
-  "hash": "50ec1dd26467218c153b504d2c88a8b78f1ffa124fdc3dc50b8e5e114b838231"
+  "hash": "226ebb1c711fd0af3205d22b7896dc95cb6efc3d5ca8d1ee070422977c3d5687"
 }

--- a/core/notifications/.sqlx/query-3f1d69c6d34a3476efb7a416fe86983e647bdee0ca1b193ace7d3303d5707fc0.json
+++ b/core/notifications/.sqlx/query-3f1d69c6d34a3476efb7a416fe86983e647bdee0ca1b193ace7d3303d5707fc0.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH anchor AS (\n                 SELECT created_at FROM stateful_notifications WHERE id = $2 LIMIT 1\n               )\n            SELECT a.id, e.sequence, e.event,\n                      a.created_at AS entity_created_at, e.recorded_at AS event_recorded_at\n            FROM stateful_notifications a\n            JOIN stateful_notification_events e ON a.id = e.id\n            WHERE a.galoy_user_id = $1 AND a.bulletin_enabled = FALSE AND (\n                    $2 IS NOT NULL AND a.created_at < (SELECT created_at FROM anchor)\n                    OR $2 IS NULL)\n            ORDER BY a.created_at DESC, a.id, e.sequence\n            LIMIT $3",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "entity_created_at",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "event_recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Uuid",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "3f1d69c6d34a3476efb7a416fe86983e647bdee0ca1b193ace7d3303d5707fc0"
+}

--- a/core/notifications/src/app/mod.rs
+++ b/core/notifications/src/app/mod.rs
@@ -295,6 +295,24 @@ impl NotificationsApp {
     }
 
     #[instrument(
+        name = "app.list_stateful_notifications_without_bulletin_enabled",
+        skip(self),
+        err
+    )]
+    pub async fn list_stateful_notifications_without_bulletin_enabled(
+        &self,
+        user_id: GaloyUserId,
+        first: usize,
+        after: Option<StatefulNotificationId>,
+    ) -> Result<(Vec<StatefulNotification>, bool), ApplicationError> {
+        let ret = self
+            .history
+            .list_notifications_without_bulletin_enabled_for_user(user_id, first, after)
+            .await?;
+        Ok(ret)
+    }
+
+    #[instrument(
         name = "app.list_unacknowledged_stateful_notifications_with_bulletin_enabled",
         skip(self),
         err

--- a/core/notifications/src/app/mod.rs
+++ b/core/notifications/src/app/mod.rs
@@ -326,17 +326,17 @@ impl NotificationsApp {
     }
 
     #[instrument(
-        name = "app.count_unacknowledged_stateful_notifications",
+        name = "app.count_unacknowledged_stateful_notifications_without_bulletin_enabled",
         skip(self),
         err
     )]
-    pub async fn count_unacknowledged_stateful_notifications(
+    pub async fn count_unacknowledged_stateful_notifications_without_bulletin_enabled(
         &self,
         user_id: GaloyUserId,
     ) -> Result<u64, ApplicationError> {
         let count = self
             .history
-            .count_unacknowledged_notifications_for_user(user_id)
+            .count_unacknowledged_notifications_without_bulletin_enabled_for_user(user_id)
             .await?;
         Ok(count)
     }

--- a/core/notifications/src/graphql/schema.rs
+++ b/core/notifications/src/graphql/schema.rs
@@ -72,14 +72,14 @@ impl User {
         .await
     }
 
-    async fn unacknowledged_stateful_notifications_count(
+    async fn unacknowledged_stateful_notifications_without_bulletin_enabled_count(
         &self,
         ctx: &Context<'_>,
     ) -> async_graphql::Result<u64> {
         let app = ctx.data_unchecked::<NotificationsApp>();
         let user_id = GaloyUserId::from(self.id.0.clone());
         let count = app
-            .count_unacknowledged_stateful_notifications(user_id)
+            .count_unacknowledged_stateful_notifications_without_bulletin_enabled(user_id)
             .await?;
         Ok::<_, async_graphql::Error>(count)
     }

--- a/core/notifications/src/history/mod.rs
+++ b/core/notifications/src/history/mod.rs
@@ -108,6 +108,17 @@ impl NotificationHistory {
         self.repo.list_for_user(user_id, first, after).await
     }
 
+    pub async fn list_notifications_without_bulletin_enabled_for_user(
+        &self,
+        user_id: GaloyUserId,
+        first: usize,
+        after: Option<StatefulNotificationId>,
+    ) -> Result<(Vec<StatefulNotification>, bool), NotificationHistoryError> {
+        self.repo
+            .list_for_user_without_bulletin_enabled(user_id, first, after)
+            .await
+    }
+
     pub async fn count_unacknowledged_notifications_without_bulletin_enabled_for_user(
         &self,
         user_id: GaloyUserId,

--- a/core/notifications/src/history/mod.rs
+++ b/core/notifications/src/history/mod.rs
@@ -108,11 +108,13 @@ impl NotificationHistory {
         self.repo.list_for_user(user_id, first, after).await
     }
 
-    pub async fn count_unacknowledged_notifications_for_user(
+    pub async fn count_unacknowledged_notifications_without_bulletin_enabled_for_user(
         &self,
         user_id: GaloyUserId,
     ) -> Result<u64, NotificationHistoryError> {
-        self.repo.count_unacknowledged_for_user(user_id).await
+        self.repo
+            .count_unacknowledged_non_bulletins_for_user(user_id)
+            .await
     }
 
     pub async fn list_unacknowledged_notifications_with_bulletin_for_user(

--- a/core/notifications/src/history/repo.rs
+++ b/core/notifications/src/history/repo.rs
@@ -78,14 +78,14 @@ impl PersistentNotifications {
         Ok(())
     }
 
-    pub async fn count_unacknowledged_for_user(
+    pub async fn count_unacknowledged_non_bulletins_for_user(
         &self,
         user_id: GaloyUserId,
     ) -> Result<u64, NotificationHistoryError> {
         let count = sqlx::query_scalar!(
             r#"SELECT COUNT(*) AS "count!"
             FROM stateful_notifications
-            WHERE galoy_user_id = $1 AND acknowledged = FALSE"#,
+            WHERE galoy_user_id = $1 AND acknowledged = FALSE AND bulletin_enabled = FALSE"#,
             user_id.as_ref(),
         )
         .fetch_one(self.read_pool.inner())

--- a/core/notifications/src/history/repo.rs
+++ b/core/notifications/src/history/repo.rs
@@ -146,6 +146,36 @@ impl PersistentNotifications {
         Ok(res)
     }
 
+    pub async fn list_for_user_without_bulletin_enabled(
+        &self,
+        user_id: GaloyUserId,
+        first: usize,
+        after: Option<StatefulNotificationId>,
+    ) -> Result<(Vec<StatefulNotification>, bool), NotificationHistoryError> {
+        let rows = sqlx::query_as!(
+            GenericEvent,
+            r#"WITH anchor AS (
+                 SELECT created_at FROM stateful_notifications WHERE id = $2 LIMIT 1
+               )
+            SELECT a.id, e.sequence, e.event,
+                      a.created_at AS entity_created_at, e.recorded_at AS event_recorded_at
+            FROM stateful_notifications a
+            JOIN stateful_notification_events e ON a.id = e.id
+            WHERE a.galoy_user_id = $1 AND a.bulletin_enabled = FALSE AND (
+                    $2 IS NOT NULL AND a.created_at < (SELECT created_at FROM anchor)
+                    OR $2 IS NULL)
+            ORDER BY a.created_at DESC, a.id, e.sequence
+            LIMIT $3"#,
+            user_id.as_ref(),
+            after as Option<StatefulNotificationId>,
+            first as i64 + 1
+        )
+        .fetch_all(self.read_pool.inner())
+        .await?;
+        let res = EntityEvents::load_n::<StatefulNotification>(rows, first)?;
+        Ok(res)
+    }
+
     pub async fn list_unacknowledged_bulletins_for_user(
         &self,
         user_id: GaloyUserId,


### PR DESCRIPTION
This PR updates notification backend for the following use cases:

1. Notification History screen requires querying only non bulletins.
2. The count displayed on top of bell icon indicating number of unacknowledged notifications must show the count for only unacknowledged non bulletins.