### PR TITLE
chore(voucher): use settlement amount to get voucher price

### DIFF
--- a/apps/voucher/app/create/client-side-page.tsx
+++ b/apps/voucher/app/create/client-side-page.tsx
@@ -70,7 +70,7 @@ export default function CreatePage({ platformFeesInPpm }: Props) {
   }, [])
 
   const voucherAmountInCents =
-    amountCalculator.voucherAmountAfterPlatformFeesAndCommission({
+    amountCalculator.voucherAmountAfterPlatformFeesAndCommission.fromPrice({
       voucherPrice: currencyConversion?.currencyConversionEstimation.usdCentAmount,
       commissionPercentage: Number(commissionPercentage),
       platformFeesInPpm,

--- a/apps/voucher/lib/amount-calculator.ts
+++ b/apps/voucher/lib/amount-calculator.ts
@@ -1,17 +1,30 @@
 export const amountCalculator = {
-  voucherAmountAfterPlatformFeesAndCommission({
-    voucherPrice,
-    commissionPercentage,
-    platformFeesInPpm,
-  }: {
-    voucherPrice: number
-    commissionPercentage: number
-    platformFeesInPpm: number
-  }): number {
-    const commissionAmount = voucherPrice * (commissionPercentage / 100)
-    const platformFees = voucherPrice * (platformFeesInPpm / 1000000)
-    const result = voucherPrice - commissionAmount - platformFees
-    return Math.max(result, 0)
+  voucherAmountAfterPlatformFeesAndCommission: {
+    fromPrice: ({
+      voucherPrice,
+      commissionPercentage,
+      platformFeesInPpm,
+    }: {
+      voucherPrice: number
+      commissionPercentage: number
+      platformFeesInPpm: number
+    }) => {
+      const commissionAmount = voucherPrice * (commissionPercentage / 100)
+      const platformFees = voucherPrice * (platformFeesInPpm / 1000000)
+      const result = voucherPrice - commissionAmount - platformFees
+      return Math.max(result, 0)
+    },
+    fromCommission: ({
+      voucherAmountAfterCommission,
+      platformFeesInPpm,
+    }: {
+      voucherAmountAfterCommission: number
+      platformFeesInPpm: number
+    }) => {
+      const platformFees = voucherAmountAfterCommission * (platformFeesInPpm / 1000000)
+      const result = voucherAmountAfterCommission - platformFees
+      return Math.max(result, 0)
+    },
   },
   voucherAmountAfterCommission({
     voucherPrice,

--- a/apps/voucher/services/db/index.ts
+++ b/apps/voucher/services/db/index.ts
@@ -165,3 +165,21 @@ export async function updateWithdrawLinkStatus({
       : new Error("Failed to update withdraw link status")
   }
 }
+
+export async function updateWithdrawLink({
+  id,
+  updates,
+}: {
+  id: string
+  updates: Partial<WithdrawLink>
+}): Promise<WithdrawLink | Error> {
+  try {
+    const [updatedWithdrawLink] = await knex("WithdrawLinks")
+      .where({ id })
+      .update(updates)
+      .returning("*")
+    return updatedWithdrawLink
+  } catch (error) {
+    return error instanceof Error ? error : new Error("Failed to update withdraw link")
+  }
+}


### PR DESCRIPTION
Previously, we handled the sales amount like this:

Sales amount = $1.05 (paid to escrow).
Voucher created for $1.04 (platform fee = 1%).

However, when using a BTC wallet to pay for the voucher, the sales amount is converted to satoshis and paid to escrow. This can lead to discrepancies (due to conversion from cents to sats). For example, we might end up paying $1.04 instead of $1.05, resulting in no platform fee being collected.

To improve accuracy, we now use the settlement amount (the actual amount paid to escrow) as the base and deduct the platform fees from that to create the voucher.

For example, if the amount paid to escrow is $1.04, we will deduct the fees from this amount and create a voucher for $1.03.