### PR TITLE
chore: demoting chatGPT error to non critical

### DIFF
--- a/core/api/src/domain/support/errors.ts
+++ b/core/api/src/domain/support/errors.ts
@@ -15,6 +15,4 @@ export class ChatAssistantNotFoundError extends SupportError {}
 
 export class TimeoutAssistantError extends SupportError {}
 
-export class UnknownChatAssistantError extends ChatAssistantError {
-  level = ErrorLevel.Critical
-}
+export class UnknownChatAssistantError extends ChatAssistantError {}

--- a/core/api/src/services/twilio-service.ts
+++ b/core/api/src/services/twilio-service.ts
@@ -197,7 +197,7 @@ export const KnownTwilioErrorMessages = {
   UnsubscribedRecipient: /unsubscribed recipient/,
   BadPhoneProviderConnection: /timeout of.*exceeded/,
   BlockedRegion:
-    /The destination phone number has been blocked by Verify Geo-Permissions. .* is blocked for sms channel for all services/,
+    /The destination phone number has been blocked by Verify Geo-Permissions. .* is blocked for SMS channel for all services/,
   RateLimitsExceeded: /Max.*attempts reached/,
   TooManyConcurrentRequests: /Too many concurrent requests/,
   FraudulentActivityBlock:


### PR DESCRIPTION
Someone would need to spend time iterating on the integration to resolve all the potential errors that may be returned by OpanAI api. in the meantime, no need to raise a critical alert every time the API return an error; at worst the bot may not return an answer. 