### PR TITLE
fix: remove unnecessary users/wallets creation/funding

### DIFF
--- a/bats/core/api/onchain-receive.bats
+++ b/bats/core/api/onchain-receive.bats
@@ -351,16 +351,6 @@ teardown() {
 }
 
 @test "onchain-receive: process received batch transaction via legacy lnd" {
-  create_user 'alice'
-  user_update_username 'alice'
-  fund_user_onchain 'alice' 'btc_wallet'
-  fund_user_onchain 'alice' 'usd_wallet'
-
-  create_user 'bob'
-  user_update_username 'bob'
-  fund_user_onchain 'bob' 'btc_wallet'
-  fund_user_onchain 'bob' 'usd_wallet'
-  
   alice_btc_wallet_name="alice.btc_wallet_id"
   alice_usd_wallet_name="alice.usd_wallet_id"
   bob_btc_wallet_name="bob.btc_wallet_id"


### PR DESCRIPTION
fix `# bats warning: Executed 134 instead of expected 135 tests` in e2e tests (users and wallets are created/funded in setup_file)