### PR TITLE
fix(core): avoid logout before initiate totp

### DIFF
--- a/core/api/src/app/authentication/totp.ts
+++ b/core/api/src/app/authentication/totp.ts
@@ -30,8 +30,11 @@ export const initiateTotpRegistration = async ({
   if (authToken instanceof Error) {
     return authToken
   }
-  const initiateResponse = kratosInitiateTotp(authToken)
+  const initiateResponse = await kratosInitiateTotp(authToken)
+  if (initiateResponse instanceof Error) return initiateResponse
+
   await logoutSessionByAuthToken(authToken)
+
   return initiateResponse
 }
 


### PR DESCRIPTION
Fix https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/C1KR8g2dQJQ?hideCompare

- if kratosInitiateTotp fail user should not be logged out
- avoid race condition when session is logged out before being able to initiate totp registration