### PR TITLE
perf(core): update username index

### DIFF
--- a/core/api/src/services/mongoose/accounts.ts
+++ b/core/api/src/services/mongoose/accounts.ts
@@ -1,4 +1,4 @@
-import { caseInsensitiveRegex, parseRepositoryError } from "./utils"
+import { parseRepositoryError } from "./utils"
 
 import { AccountStatus } from "@/domain/accounts"
 import {
@@ -44,7 +44,9 @@ export const AccountsRepository = (): IAccountsRepository => {
     username: Username,
   ): Promise<Account | RepositoryError> => {
     try {
-      const result = await Account.findOne({ username: caseInsensitiveRegex(username) })
+      const result = await Account.findOne({ username })
+        .collation({ locale: "en", strength: 2 })
+        .hint({ username: 1 })
       if (!result) {
         return new CouldNotFindAccountFromUsernameError(username)
       }

--- a/core/api/src/services/mongoose/schema.ts
+++ b/core/api/src/services/mongoose/schema.ts
@@ -202,13 +202,18 @@ const AccountSchema = new Schema<AccountRecord>(
 
     username: {
       type: String,
-      match: [UsernameRegex, "Username can only have alphabets, numbers and underscores"],
+      match: [
+        UsernameRegex,
+        "Username can only have alphabets, numbers, and underscores",
+      ],
       minlength: 3,
       maxlength: 50,
       index: {
         unique: true,
         collation: { locale: "en", strength: 2 },
-        partialFilterExpression: { username: { $type: "string" } },
+        partialFilterExpression: {
+          username: { $type: "string", $exists: true, $ne: null },
+        },
       },
     },
     contactEnabled: {

--- a/core/api/src/services/mongoose/schema.ts
+++ b/core/api/src/services/mongoose/schema.ts
@@ -212,7 +212,7 @@ const AccountSchema = new Schema<AccountRecord>(
         unique: true,
         collation: { locale: "en", strength: 2 },
         partialFilterExpression: {
-          username: { $type: "string", $exists: true, $ne: null },
+          username: { $type: "string", $exists: true },
         },
       },
     },


### PR DESCRIPTION
Avg duration is more than 1 second https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/71kKbg8xRg6?hideCompare

- Add to username index only records with a valid value
- Remove regex query (improves performance)
- Force the use of username index (I tested it directly and for some reason is not using the index without the hint)