### PR TITLE
perf(core): improve backward pagination

### DIFF
--- a/core/api/src/services/ledger/paginated-ledger.ts
+++ b/core/api/src/services/ledger/paginated-ledger.ts
@@ -85,7 +85,7 @@ export const paginatedLedger = async ({
 
     if (transactionRecords.length > last) {
       hasPreviousPage = true
-      transactionRecords = transactionRecords.slice(1) // Remove the extra record
+      transactionRecords = transactionRecords.slice(0, last) // Remove the extra record
     }
 
     // Reverse the results to maintain consistent ordering (newest first)


### PR DESCRIPTION
- now it is using new index correctly but the use of skip is a bad practice specially for accounts with more than 500k transactions
- improve performance removing count query

tests that cover pagination: https://github.com/GaloyMoney/blink/blob/main/core/api/test/integration/services/ledger-service.spec.ts#L59