### PR TITLE
chore(core): update default btc invoice expiration to 2 hours

### DIFF
--- a/core/api/src/domain/bitcoin/lightning/invoice-expiration.ts
+++ b/core/api/src/domain/bitcoin/lightning/invoice-expiration.ts
@@ -3,12 +3,13 @@ import { toSeconds } from "@/domain/primitives"
 const SECS_PER_MIN = toSeconds(60)
 const SECS_PER_5_MINS = toSeconds(60 * 5)
 const SECS_PER_HOUR = toSeconds(60 * 60)
+const SECS_PER_2_HOURS = toSeconds(SECS_PER_HOUR * 2)
 const SECS_PER_DAY = toSeconds(SECS_PER_HOUR * 24)
 
 export const defaultTimeToExpiryInSeconds = SECS_PER_5_MINS
 
 export const INVOICE_EXPIRATIONS = {
-  BTC: { min: SECS_PER_MIN, max: SECS_PER_DAY, defaultValue: SECS_PER_HOUR },
+  BTC: { min: SECS_PER_MIN, max: SECS_PER_DAY, defaultValue: SECS_PER_2_HOURS },
   USD: { min: SECS_PER_MIN, max: SECS_PER_5_MINS, defaultValue: SECS_PER_5_MINS },
 }
 


### PR DESCRIPTION
Increase default timeout to avoid issues with lnp2pbot invoice expiration window https://github.com/lnp2pBot/bot/blob/main/.env-sample#L26