### PR TITLE
fix(pay): disable comment in lnurl pay

### DIFF
--- a/apps/pay/app/lnurlp/[username]/route.ts
+++ b/apps/pay/app/lnurlp/[username]/route.ts
@@ -12,7 +12,7 @@ import { getOriginalRequestInfo } from "@/lib/utils"
 
 import { client } from "@/app/lnurlp/[username]/graphql"
 
-const COMMENT_SIZE = 2000 // 2000 characters max for GET
+const COMMENT_SIZE = 0 // 2000 characters max for GET
 
 const nostrEnabled = !!env.NOSTR_PUBKEY
 


### PR DESCRIPTION
it is not implemented in the callback and adding to the memo will modify description hash. Implement this would require additional metadata to be added to a payment