### PR TITLE
fix(core): allow ln payment retries when there is a temporary channel failure

### DIFF
--- a/core/api/src/domain/payments/index.types.d.ts
+++ b/core/api/src/domain/payments/index.types.d.ts
@@ -427,4 +427,7 @@ interface IPaymentFlowRepository {
     paymentFlowIndex: PaymentFlowStateIndex,
   ): Promise<PaymentFlow<S, WalletCurrency> | RepositoryError>
   deleteExpiredLightningPaymentFlows(): Promise<number | RepositoryError>
+  deleteLightningPaymentFlow<S extends WalletCurrency>(
+    paymentFlow: PaymentFlow<S, WalletCurrency>,
+  ): Promise<true | RepositoryError>
 }

--- a/core/api/src/services/mongoose/payment-flow.ts
+++ b/core/api/src/services/mongoose/payment-flow.ts
@@ -62,7 +62,7 @@ export const PaymentFlowStateRepository = (
       if (paymentFlow instanceof Error) return paymentFlow
 
       if (isExpired({ paymentFlow, expiryTimeInSeconds })) {
-        deleteLightningPaymentFlow({ ...hash, walletId, inputAmount })
+        deletePaymentFlow({ ...hash, walletId, inputAmount })
         return new CouldNotFindLightningPaymentFlowError()
       }
 
@@ -128,7 +128,7 @@ export const PaymentFlowStateRepository = (
     }
   }
 
-  const deleteLightningPaymentFlow = async ({
+  const deletePaymentFlow = async ({
     walletId,
     paymentHash,
     intraLedgerHash,
@@ -173,12 +173,26 @@ export const PaymentFlowStateRepository = (
     }
   }
 
+  const deleteLightningPaymentFlow = async <
+    S extends WalletCurrency,
+    R extends WalletCurrency,
+  >(
+    paymentFlow: PaymentFlow<S, R>,
+  ): Promise<true | RepositoryError> => {
+    const { senderWalletId: walletId, paymentHash, inputAmount } = paymentFlow
+    if (!paymentHash) {
+      return new BadInputsForFindError(JSON.stringify(paymentFlow))
+    }
+    return deletePaymentFlow({ paymentHash, walletId, inputAmount })
+  }
+
   return {
     findLightningPaymentFlow,
     persistNew,
     updateLightningPaymentFlow,
     markLightningPaymentFlowNotPending,
     deleteExpiredLightningPaymentFlows,
+    deleteLightningPaymentFlow,
   }
 }
 


### PR DESCRIPTION
fix https://ui.honeycomb.io/galoy/datasets/galoy-bbw/result/p5q5Uq3v2ax/trace/smfnUqb11hn?fields[]=s_name&fields[]=s_serviceName&span=bfbb36035721b87e