### PR TITLE
feat: support for additional cold storage wallet

### DIFF
--- a/core/api/galoy.yaml
+++ b/core/api/galoy.yaml
@@ -35,8 +35,11 @@ bria:
   queueNames:
     fast: dev-queue
   coldStorage:
-    walletName: cold
+    activeRebalanceWalletName: cold
     hotToColdRebalanceQueueName: dev-queue
+    coldWallets:
+      - name: cold
+        walletName: cold
 lndScbBackupBucketName: lnd-static-channel-backups
 admin_accounts:
   - role: dealer

--- a/core/api/src/app/on-chain/index.ts
+++ b/core/api/src/app/on-chain/index.ts
@@ -9,9 +9,11 @@ export const getHotBalance = async (): Promise<BtcPaymentAmount | ApplicationErr
   return service.getHotBalance()
 }
 
-export const getColdBalance = async (): Promise<BtcPaymentAmount | ApplicationError> => {
+export const getColdBalance = async (
+  walletName?: string,
+): Promise<BtcPaymentAmount | ApplicationError> => {
   const service = OnChainService()
-  return service.getColdBalance()
+  return service.getColdBalance(walletName)
 }
 
 export const getBatchInclusionEstimatedAt = async ({

--- a/core/api/src/config/schema.ts
+++ b/core/api/src/config/schema.ts
@@ -196,13 +196,37 @@ export const configSchema = {
         coldStorage: {
           type: "object",
           properties: {
-            walletName: { type: "string" },
             hotToColdRebalanceQueueName: { type: "string" },
+            activeRebalanceWalletName: { type: "string" },
+            coldWallets: {
+              type: "array",
+              items: {
+                type: "object",
+                properties: {
+                  name: { type: "string" },
+                  walletName: { type: "string" },
+                },
+                required: ["name", "walletName"],
+                additionalProperties: false,
+              },
+              minItems: 1,
+              uniqueItems: true,
+            },
           },
-          required: ["walletName", "hotToColdRebalanceQueueName"],
+          required: [
+            "hotToColdRebalanceQueueName",
+            "activeRebalanceWalletName",
+            "coldWallets",
+          ],
           default: {
-            walletName: "cold",
             hotToColdRebalanceQueueName: "dev-queue",
+            activeRebalanceWalletName: "cold",
+            coldWallets: [
+              {
+                name: "cold",
+                walletName: "cold",
+              },
+            ],
           },
         },
       },

--- a/core/api/src/config/schema.types.d.ts
+++ b/core/api/src/config/schema.types.d.ts
@@ -57,8 +57,12 @@ type YamlSchema = {
       fast: string
     }
     coldStorage: {
-      walletName: string
       hotToColdRebalanceQueueName: string
+      activeRebalanceWalletName: string
+      coldWallets: {
+        name: string
+        walletName: string
+      }[]
     }
   }
   lndScbBackupBucketName: string

--- a/core/api/src/domain/bitcoin/onchain/index.types.d.ts
+++ b/core/api/src/domain/bitcoin/onchain/index.types.d.ts
@@ -102,7 +102,7 @@ type OnChainEventHandler = (event: OnChainEvent) => true | ApplicationError
 
 interface IOnChainService {
   getHotBalance(): Promise<BtcPaymentAmount | OnChainServiceError>
-  getColdBalance(): Promise<BtcPaymentAmount | OnChainServiceError>
+  getColdBalance(walletName?: string): Promise<BtcPaymentAmount | OnChainServiceError>
   getAddressForWallet(args: {
     walletDescriptor: WalletDescriptor<WalletCurrency>
     requestId?: OnChainAddressRequestId


### PR DESCRIPTION
# PR Summary: Support for Additional Cold Storage Wallet

## Overview
This pull request adds support for monitoring an additional cold storage wallet in the Blink system. The implementation allows for configuring and tracking the balance of a secondary cold wallet alongside the default cold storage wallet.

## Key Changes

1. **Configuration Schema Updates**:
   - Added configuration options for an additional cold wallet in the schema
   - Made the additional wallet feature optional with a default value of `null`
   - Added type definitions for the new configuration options

2. **Bria Service Enhancements**:
   - Modified the `getColdBalance` function to accept an optional wallet name parameter
   - Added helper function `findColdWalletName` to resolve wallet identifiers to actual wallet names
   - Implemented logic to handle both default and additional cold wallets

3. **Monitoring and Metrics**:
   - Added a new Prometheus gauge for the additional cold wallet named `additional_bria_cold_storage`
   - Updated asset calculation functions to include the additional cold wallet balance
   - Improved logging to include the additional cold wallet balance

4. **API Updates**:
   - Updated the OnChain API to support querying the balance of a specific cold wallet

## Technical Details
- The implementation supports multiple cold wallets through a configuration list
- One wallet is designated as the active rebalance wallet (used for rebalancing operations)
- The additional wallets are completely optional and the system works normally with just the default wallet
- The metric name for the active rebalance wallet remains `bria_cold_storage` for backward compatibility
- Additional cold wallets use the naming pattern `bria_cold_storage_${walletName}`
- The PR includes proper error handling for cases when the additional wallet is not available

## Impact
This change enhances the monitoring capabilities of the Blink system by allowing operators to track the balance of multiple cold storage wallets in Grafana dashboards. This is particularly useful for environments that maintain multiple cold wallets for different purposes.

## Implementation Notes
- The configuration structure has been updated to use a list of cold wallets with one designated as active
- Asset calculations now include the sum of all cold wallet balances
- The exporter server has been updated to create separate Prometheus gauges for each cold wallet
- Backward compatibility is maintained by keeping the original metric name for the active wallet
