### PR TITLE
fix(pay): make server side LNURL request to avoid CORS issue

### DIFF
--- a/apps/pay/app/api/lnurl-proxy/route.ts
+++ b/apps/pay/app/api/lnurl-proxy/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from "next/server"
+import { getParams } from "js-lnurl"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { lnurl, paymentRequest } = await request.json()
+
+    if (!lnurl) {
+      return NextResponse.json(
+        { error: "Missing lnurl parameter" },
+        { status: 400 }
+      )
+    }
+
+    // If we have both lnurl and paymentRequest, we're doing a direct payment
+    if (lnurl && paymentRequest) {
+      const lnurlParams = await getParams(lnurl)
+
+      if (!("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest")) {
+        return NextResponse.json(
+          { error: "Not a properly configured lnurl withdraw tag" },
+          { status: 400 }
+        )
+      }
+
+      const { callback, k1 } = lnurlParams
+
+      const urlObject = new URL(callback)
+      const searchParams = urlObject.searchParams
+      searchParams.set("k1", k1)
+      searchParams.set("pr", paymentRequest)
+
+      const url = urlObject.toString()
+
+      const result = await fetch(url)
+      const data = await result.json()
+
+      return NextResponse.json(data, { status: result.ok ? 200 : 400 })
+    }
+
+    // If we only have lnurl, just get the params
+    const params = await getParams(lnurl)
+    return NextResponse.json(params)
+  } catch (error) {
+    console.error("Error processing LNURL request:", error)
+    return NextResponse.json(
+      { error: "Failed to process LNURL request" },
+      { status: 500 }
+    )
+  }
+}

--- a/apps/pay/app/api/lnurl-proxy/route.ts
+++ b/apps/pay/app/api/lnurl-proxy/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: NextRequest) {
 
     const lnurlParams = await getParams(lnurl)
 
-    if (lnurlParams.tag !== "withdrawRequest") {
+    if (!("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest")) {
       return NextResponse.json(
         { error: "Not a properly configured lnurl withdraw tag" },
         { status: 400 }

--- a/apps/pay/app/api/lnurl-proxy/route.ts
+++ b/apps/pay/app/api/lnurl-proxy/route.ts
@@ -12,31 +12,36 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    // If we have both lnurl and paymentRequest, we're doing a direct payment
-    if (lnurl && paymentRequest) {
-      const lnurlParams = await getParams(lnurl)
-
-      if (!("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest")) {
-        return NextResponse.json(
-          { error: "Not a properly configured lnurl withdraw tag" },
-          { status: 400 }
-        )
-      }
-
-      const { callback, k1 } = lnurlParams
-
-      const urlObject = new URL(callback)
-      const searchParams = urlObject.searchParams
-      searchParams.set("k1", k1)
-      searchParams.set("pr", paymentRequest)
-
-      const url = urlObject.toString()
-
-      const result = await fetch(url)
-      const data = await result.json()
-
-      return NextResponse.json(data, { status: result.ok ? 200 : 400 })
+    if (!paymentRequest) {
+      return NextResponse.json(
+        { error: "Missing paymentRequest parameter" },
+        { status: 400 }
+      )
     }
+
+    const lnurlParams = await getParams(lnurl)
+
+    if (lnurlParams.tag !== "withdrawRequest") {
+      return NextResponse.json(
+        { error: "Not a properly configured lnurl withdraw tag" },
+        { status: 400 }
+      )
+    }
+
+    const { callback, k1 } = lnurlParams
+
+    const urlObject = new URL(callback)
+    const searchParams = urlObject.searchParams
+    searchParams.set("k1", k1)
+    searchParams.set("pr", paymentRequest)
+
+    const url = urlObject.toString()
+
+    const result = await fetch(url)
+    const data = await result.json()
+
+    return NextResponse.json(data, { status: result.ok ? 200 : 400 })
+
 
     // If we only have lnurl, just get the params
     const params = await getParams(lnurl)

--- a/apps/pay/app/api/lnurl-proxy/route.ts
+++ b/apps/pay/app/api/lnurl-proxy/route.ts
@@ -41,11 +41,6 @@ export async function POST(request: NextRequest) {
     const data = await result.json()
 
     return NextResponse.json(data, { status: result.ok ? 200 : 400 })
-
-
-    // If we only have lnurl, just get the params
-    const params = await getParams(lnurl)
-    return NextResponse.json(params)
   } catch (error) {
     console.error("Error processing LNURL request:", error)
     return NextResponse.json(

--- a/apps/pay/app/api/lnurl-proxy/route.ts
+++ b/apps/pay/app/api/lnurl-proxy/route.ts
@@ -6,16 +6,13 @@ export async function POST(request: NextRequest) {
     const { lnurl, paymentRequest } = await request.json()
 
     if (!lnurl) {
-      return NextResponse.json(
-        { error: "Missing lnurl parameter" },
-        { status: 400 }
-      )
+      return NextResponse.json({ error: "Missing lnurl parameter" }, { status: 400 })
     }
 
     if (!paymentRequest) {
       return NextResponse.json(
         { error: "Missing paymentRequest parameter" },
-        { status: 400 }
+        { status: 400 },
       )
     }
 
@@ -24,7 +21,7 @@ export async function POST(request: NextRequest) {
     if (!("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest")) {
       return NextResponse.json(
         { error: "Not a properly configured lnurl withdraw tag" },
-        { status: 400 }
+        { status: 400 },
       )
     }
 
@@ -45,7 +42,7 @@ export async function POST(request: NextRequest) {
     console.error("Error processing LNURL request:", error)
     return NextResponse.json(
       { error: "Failed to process LNURL request" },
-      { status: 500 }
+      { status: 500 },
     )
   }
 }

--- a/apps/pay/components/parse-pos-payment/nfc.tsx
+++ b/apps/pay/components/parse-pos-payment/nfc.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react"
+
 import LoadingComponent from "../loading"
 
 import styles from "./parse-payment.module.css"

--- a/apps/pay/components/parse-pos-payment/nfc.tsx
+++ b/apps/pay/components/parse-pos-payment/nfc.tsx
@@ -1,7 +1,4 @@
 import React, { useState, useEffect } from "react"
-// Import removed as we'll use our proxy instead
-// import { getParams } from "js-lnurl"
-
 import LoadingComponent from "../loading"
 
 import styles from "./parse-payment.module.css"

--- a/apps/pay/components/parse-pos-payment/nfc.tsx
+++ b/apps/pay/components/parse-pos-payment/nfc.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from "react"
-import { getParams } from "js-lnurl"
+// Import removed as we'll use our proxy instead
+// import { getParams } from "js-lnurl"
 
 import LoadingComponent from "../loading"
 
@@ -155,28 +156,19 @@ function NFCComponent({ paymentRequest }: Props) {
         })
 
       setIsLoading(true)
-      const lnurlParams = await getParams(nfcMessage)
 
-      if (!("tag" in lnurlParams && lnurlParams.tag === "withdrawRequest")) {
-        alert(
-          `not a properly configured lnurl withdraw tag\n\n${nfcMessage}\n\n${
-            "reason" in lnurlParams && lnurlParams.reason
-          }`,
-        )
-        setIsLoading(false)
-        return
-      }
-
-      const { callback, k1 } = lnurlParams
-
-      const urlObject = new URL(callback)
-      const searchParams = urlObject.searchParams
-      searchParams.set("k1", k1)
-      searchParams.set("pr", paymentRequest)
-
-      const url = urlObject.toString()
-
-      const result = await fetch(url)
+      // Use our proxy endpoint to handle the LNURL request
+      // This avoids CORS issues by making the request server-side
+      const result = await fetch("/api/lnurl-proxy", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          lnurl: nfcMessage,
+          paymentRequest,
+        }),
+      })
       if (result.ok) {
         const lnurlResponse = await result.json()
         if (lnurlResponse?.status?.toLowerCase() !== "ok") {
@@ -195,7 +187,7 @@ function NFCComponent({ paymentRequest }: Props) {
             errorMessage += decoded.message
           }
         } finally {
-          let message = `Error processing payment.\n\nHTTP error code: ${result.status}`
+          let message = `Error processing boltcard payment.\n\nHTTP error code: ${result.status}`
           if (errorMessage) {
             message += `\n\nError message: ${errorMessage}`
           }
@@ -244,7 +236,7 @@ function NFCComponent({ paymentRequest }: Props) {
             disabled={hasNFCPermission || !isNfcSupported}
           >
             {!isNfcSupported
-              ? "Bold card not supported"
+              ? "Bolt card not supported"
               : hasNFCPermission
                 ? "Boltcard activated"
                 : "Activate boltcard"}


### PR DESCRIPTION
# Fix CORS error when using BTCPayServer-issued bolt cards

## Problem

The Blink POS system experiences CORS errors when trying to use BTCPayServer-issued bolt cards. This happens because the system attempts to make direct browser-to-LNURL-server requests, which fail due to CORS restrictions.

Other POS systems (LNbits TPOS, BTCPay) don't have this issue because they handle LNURL requests server-side.

## Solution

Implemented a server-side proxy approach to avoid CORS restrictions:

1. Created a server-side proxy endpoint for LNURL requests
2. Modified the NFC component to send requests through the proxy instead of directly using js-lnurl
3. Fixed a typo in the UI ("Bold card" → "Bolt card")

## How It Works

- When a bolt card is tapped, the NFC component sends both the LNURL and payment request to our server-side proxy
- The proxy handles all communication with the LNURL server, avoiding CORS issues
- The proxy returns the result to the client

This approach mirrors how LNbits and BTCPay handle bolt cards, which is why they don't experience CORS issues.

## Testing

Verify that the solution works with BTCPayServer-issued bolt cards by confirming:
- No CORS errors appear in the browser console
- Payments process successfully

Fixes #4825
